### PR TITLE
Add Scenes

### DIFF
--- a/lib/wink.rb
+++ b/lib/wink.rb
@@ -2,6 +2,7 @@ require "wink/version"
 require "wink/config"
 require "wink/client"
 require "wink/devices"
+require "wink/scene"
 
 module Wink
   extend Config

--- a/lib/wink/client.rb
+++ b/lib/wink/client.rb
@@ -5,6 +5,33 @@ require "addressable/template"
 
 module Wink
   class Client
+
+    # Public: Lookup all scenes on your Wink account.
+    #
+    # Returns Array of Wink::Scene instances.
+    def scenes
+      response = get('/users/me/scenes')
+      response.body["data"].collect do |scene|
+        Scene.new(self, scene)
+      end
+    end
+
+    # Public: Lookup an individual scene on your Wink account.
+    #
+    # scene - The id or name of the scene to look up.
+    #
+    # Returns Wink::Scene instance.
+    def scene(scene_identifier)
+      if scene_identifier.is_a?(Numeric) || scene_identifier.to_i.to_s == scene_identifier
+        # passed in a scene id
+        response = get('/scenes{/scene}', :scene => scene_identifier)
+        Scene.new(self, response.body['data'])
+      else
+        # passed in a name
+        scenes.detect{|s| s.name.downcase == scene_identifier.downcase}
+      end
+    end
+
     def devices
       response = get('/users/me/wink_devices')
       response.body["data"].collect do |device|

--- a/lib/wink/scene.rb
+++ b/lib/wink/scene.rb
@@ -1,0 +1,26 @@
+module Wink
+  class Scene
+    attr_reader :client
+    attr_reader :scene
+    attr_reader :scene_id
+
+    def initialize(client, scene)
+      @client = client
+      @scene = scene
+
+      @scene_id  = scene.fetch("scene_id")
+    end
+
+    def id
+      scene_id
+    end
+
+    def name
+      scene['name']
+    end
+
+    def activate
+      client.post('/scenes{/scene}/activate', :scene => scene_id)
+    end
+  end
+end


### PR DESCRIPTION
This adds rudimentary Scene support. Scenes are basically what they call Shortcuts in the Wink App.

The only thing you can do is list them and activate them. You can't create them, edit them, delete them, or even list what their associated object properties are.

But hey, thats what the app is for, making these things. At least you can list them and activate them with the lib.
